### PR TITLE
Make it work on all sites and several improvements

### DIFF
--- a/content.js
+++ b/content.js
@@ -10,12 +10,12 @@ function priceTime(price) {
   const minutes = calculateMinutes(timeInMinutes, hours) 
   if (timeInMinutes >= 60) {
   	return minutes === 0 && hours 
-		? `This costs ${generateHours(hours)} on minimum wage` 
-		: `This costs ${generateHours(hours)} and ${generateMinutes(minutes)}`
+		? `${generateHours(hours)} on minimum wage` 
+		: `${generateHours(hours)} and ${generateMinutes(minutes)}`
   } 
 	return minutes < 1 
-  		? 'This costs less than a minute on minimum wage'
-	    : `This costs ${generateMinutes(minutes)}`
+  		? 'Less than a minute on minimum wage'
+	    : `${generateMinutes(minutes)}`
 }
 
 function isNegative(num) {
@@ -33,19 +33,32 @@ function calculateHours(minutes) {
 function generateMinutes(minutes) {
 	return minutes < 1 ? `less than a minute on minimum wage` 
 		: `${minutes} ${minutes > 1 ? 'minutes' : 'minute'} on minimum wage`
-}
+}``
 
 function generateHours(hours) {
 	return `${hours} ${hours > 1 ? 'hours' : 'hour'}`
 }
 
-const prices = document.getElementsByClassName('a-color-price'); //amazon class for prices
+function treeWalkTextNodes() {
+  var n, result = [],
+  walk = document.createTreeWalker(document.getElementsByTagName("body")[0], NodeFilter.SHOW_TEXT, null, false);
+  while (n = walk.nextNode()) result.push(n);
+
+  return result.filter(node => node.textContent.includes("£")).map(r => r.parentElement);
+}
+
+const prices = treeWalkTextNodes();
 for (const priceElement of prices) {
   try {
-    const price = getPriceNumber(priceElement)
-    if (!price) {
-      priceElement.innerText = priceTime(price);
-    }
+    const result = [];
+    
+    priceElement.innerText.split(' ').forEach((text) => {
+      if(!text.startsWith("£")) return result.push(text);
+
+      result.push(priceTime(parseInt(text.split("£")[1])));
+    });
+
+    priceElement.innerText = result.join(' ');
   }
   catch(err){
     continue
@@ -53,8 +66,9 @@ for (const priceElement of prices) {
 }
 
 function getPriceNumber(price) {
-	if (!price || !price.innerText) {
+	if (!price || !price.innerText.trim()) {
 		return 0
-	}
+  }
+  
 	return Number(price.innerText.split('£')[1].split(' ')[0])
 }

--- a/content.js
+++ b/content.js
@@ -49,6 +49,8 @@ function treeWalkTextNodes() {
 
 const prices = treeWalkTextNodes();
 for (const priceElement of prices) {
+  if(priceElement.innerText.length == 1) continue;
+
   const result = [];
   
   priceElement.innerText.split(' ').forEach((text) => {

--- a/content.js
+++ b/content.js
@@ -49,26 +49,13 @@ function treeWalkTextNodes() {
 
 const prices = treeWalkTextNodes();
 for (const priceElement of prices) {
-  try {
-    const result = [];
-    
-    priceElement.innerText.split(' ').forEach((text) => {
-      if(!text.startsWith("£")) return result.push(text);
-
-      result.push(priceTime(parseInt(text.split("£")[1])));
-    });
-
-    priceElement.innerText = result.join(' ');
-  }
-  catch(err){
-    continue
-  }
-}
-
-function getPriceNumber(price) {
-	if (!price || !price.innerText.trim()) {
-		return 0
-  }
+  const result = [];
   
-	return Number(price.innerText.split('£')[1].split(' ')[0])
+  priceElement.innerText.split(' ').forEach((text) => {
+    if(!text.startsWith("£")) return result.push(text);
+
+    result.push(priceTime(parseInt(text.split("£")[1])));
+  });
+
+  priceElement.innerText = result.join(' ');
 }

--- a/manifest.json
+++ b/manifest.json
@@ -7,7 +7,7 @@
 
   "content_scripts": [{
     "js": ["content.js"],
-    "matches": ["https://www.amazon.co.uk/*"]
+    "matches": ["<all_urls>"]
   }]
 
 }


### PR DESCRIPTION
Beyond bored so I did this:

- Makes it work on every site, not only amazon. This uses a not very well know but extremely useful node walker built into the browser, `createTreeWalker`.
- Makes it so that if the text contains a price, instead of replacing the whole piece of text, it replaces only the piece of text that contains the price, which can result in some quite funny results.
- Removed "This costs ..." because it doesn't really work on other sites and doesn't look too great on amazon either.
- Changes the manifest matches to be all urls
- Cleans up a bit of the code

Some examples of this working across the internet:
## Razer:

![image](https://user-images.githubusercontent.com/18425863/78508444-e3d20d00-777e-11ea-9e1c-d12d14380ddf.png)
## Ebay:

![image](https://user-images.githubusercontent.com/18425863/78508456-fa786400-777e-11ea-8e5a-1de3d94dbbf7.png)
## Spotify:

![image](https://user-images.githubusercontent.com/18425863/78508497-39a6b500-777f-11ea-8938-3da918014d8a.png)

I didn't update tests because I'm not too sure about your setup, and I've only used jasmine a few times before.

Hopefully this doesn't blow the scope of the project haha. Some improvements of this I can think of is creating a like slider in the extension to dynamically enable/disable it.